### PR TITLE
Fix Dockerfile permissions, update healthcheck, and improve test encryption key setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,10 @@ RUN sed -i 's/opn(authorizeUrl, { wait: false }).then(cp => cp.unref());/process
 # Build TypeScript now that source files are available
 RUN npm run build
 
-# Create necessary directories
-RUN mkdir -p /credentials /app/logs
+# Create necessary directories with appropriate permissions
+RUN mkdir -p /credentials /app/logs && \
+    chmod 700 /credentials && \
+    chmod 755 /app/logs
 
 # Create volume for credentials
 VOLUME ["/credentials"]
@@ -40,7 +42,7 @@ ENV NODE_ENV=production
 
 # Health check - using the built-in health check functionality
 HEALTHCHECK --interval=5m --timeout=10s --start-period=30s --retries=3 \
-  CMD node dist/index.js health || exit 1
+  CMD ["node", "dist/health-check.js"]
 
 # Run the MCP server
 CMD ["node", "dist/index.js"]

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -106,8 +106,9 @@ All token operations are logged in JSON format:
 ### Environment Variables
 
 ```bash
-# Required - 32-byte encryption key
-GDRIVE_TOKEN_ENCRYPTION_KEY=base64_encoded_32_byte_key
+# Required - Generate 32 random bytes (44-character base64 string)
+# Generate with: openssl rand -base64 32
+GDRIVE_TOKEN_ENCRYPTION_KEY=base64_encoded_32_byte_key_44_chars
 
 # Optional - Token refresh settings
 GDRIVE_TOKEN_REFRESH_INTERVAL=1800000  # 30 minutes

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,10 +1,11 @@
 // Jest setup file for test environment configuration
 import { jest } from '@jest/globals';
+import crypto from 'crypto';
 
 // Set test environment variables
 process.env.NODE_ENV = 'test';
 process.env.LOG_LEVEL = 'error'; // Reduce noise in tests
-process.env.GDRIVE_TOKEN_ENCRYPTION_KEY = Buffer.from(new Uint8Array(32)).toString('base64'); // Test encryption key
+process.env.GDRIVE_TOKEN_ENCRYPTION_KEY = Buffer.from(crypto.randomBytes(32)).toString('base64'); // Test encryption key
 
 // Mock winston to prevent file writes during tests
 jest.mock('winston', () => {


### PR DESCRIPTION
## Summary
- Adjust Dockerfile to set proper permissions on directories
- Update Dockerfile health check command to use dedicated script
- Clarify environment variable instructions for token encryption key
- Improve Jest test setup to generate a random encryption key

## Changes

### Dockerfile
- Added `chmod 700` for `/credentials` and `chmod 755` for `/app/logs` to ensure correct permissions
- Changed health check command to `node dist/health-check.js` for better separation

### Documentation
- Updated `authentication.md` to specify generating a 44-character base64 encryption key using `openssl rand -base64 32`

### Jest Setup
- Modified `jest.setup.js` to import `crypto` and generate a random 32-byte base64 encryption key for tests instead of a zeroed buffer

## Test plan
- [x] Build Docker image and verify directory permissions
- [x] Run health check command successfully inside container
- [x] Validate updated environment variable instructions in documentation
- [x] Run Jest tests and confirm encryption key is randomly generated and tests pass

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9f8d01e3-fdde-4eb7-9be9-798c9eac9bc9