### PR TITLE
Add formatCells tool for Sheets formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ✨ **Sheets Formatting**: Added `formatCells` tool to apply bold/italic text, colors, and number format presets with dynamic field masks and helper utilities.
+
 ## [0.8.0] - 2025-08-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This is a Model Context Protocol (MCP) server for Google Drive integration. It p
 - Full read/write access to Google Drive files and folders
 - Resource access to Google Drive files via `gdrive:///<file_id>` URIs
 - Tools for searching, reading, creating, and updating files
-- Comprehensive Google Sheets operations (read, update, append)
+- Comprehensive Google Sheets operations (read, update, append, format)
 - Google Forms creation and management with question types
 - **Google Docs API integration** - Create documents, insert text, replace text, apply formatting, insert tables
 - **Batch file operations** - Process multiple files in a single operation (create, update, delete, move)
@@ -85,7 +85,7 @@ Reference agents naturally in development tasks, e.g., "As dev, implement..." or
 - **Tools**: 
   - **Read Operations**: search, read, listSheets, readSheet
   - **Write Operations**: createFile, updateFile, createFolder
-  - **Sheets Operations**: updateCells, appendRows
+  - **Sheets Operations**: updateCells, appendRows, formatCells
   - **Forms Operations**: createForm, getForm, addQuestion, listResponses
   - **Docs Operations**: createDocument, insertText, replaceText, applyTextStyle, insertTable
   - **Batch Operations**: batchFileOperations (create, update, delete, move multiple files)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ node ./dist/index.js auth
 ### 📊 **Google Sheets Integration**
 - **Data Access** - Read and write sheet data with A1 notation support
 - **Sheet Management** - List sheets, update cells, append rows
+- **Cell Formatting** - Apply bold/italic text, colors, and number formats with the `formatCells` tool
 - **CSV Export** - Automatic conversion for data analysis
 
 ### 📝 **Google Docs Manipulation**
@@ -206,11 +207,11 @@ graph TB
 
 ### 📖 Available Tools
 
-The server provides **22 comprehensive tools** for Google Workspace integration across **6 categories**:
+The server provides **23 comprehensive tools** for Google Workspace integration across **6 categories**:
 
 - **🔍 Search & Read** (6 tools): search, enhancedSearch, read, listSheets, readSheet, getAppScript
 - **📁 File & Folder** (4 tools): createFile, updateFile, createFolder, batchFileOperations
-- **📊 Sheets** (2 tools): updateCells, appendRows
+- **📊 Sheets** (3 tools): updateCells, appendRows, formatCells
 - **📋 Forms** (4 tools): createForm, getForm, addQuestion, listResponses
 - **📝 Docs** (5 tools): createDocument, insertText, replaceText, applyTextStyle, insertTable
 - **📂 Resources**: MCP resource access via `gdrive:///<file_id>` URIs

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,16 @@ import { AuthManager, AuthState } from "./src/auth/AuthManager.js";
 import { TokenManager } from "./src/auth/TokenManager.js";
 import { KeyRotationManager } from "./src/auth/KeyRotationManager.js";
 import { performHealthCheck, HealthStatus } from "./src/health-check.js";
+import {
+  buildFieldMask,
+  clearGridRangeCacheForSheet,
+  clearSpreadsheetMetadata,
+  resolveGridRange,
+  toSheetsColor,
+  type CellFormat,
+  type FormatCellsInput,
+  type TextFormat,
+} from "./src/sheets/helpers.js";
 
 const drive = google.drive("v3");
 const sheets = google.sheets("v4");
@@ -901,6 +911,78 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: "formatCells",
+        description: "Apply formatting to cells (bold, colors, number formats) in Google Sheets",
+        inputSchema: {
+          type: "object",
+          properties: {
+            spreadsheetId: {
+              type: "string",
+              description: "The ID of the Google Sheets document",
+            },
+            range: {
+              type: "string",
+              description: "The A1 notation range to format (e.g., 'Sheet1!A1:B2')",
+            },
+            format: {
+              type: "object",
+              description: "Formatting options to apply to the cells",
+              properties: {
+                bold: {
+                  type: "boolean",
+                  description: "Apply bold styling to text",
+                },
+                italic: {
+                  type: "boolean",
+                  description: "Apply italic styling to text",
+                },
+                fontSize: {
+                  type: "number",
+                  description: "Font size in points (e.g., 12)",
+                },
+                foregroundColor: {
+                  type: "object",
+                  description: "Text color using 0.0-1.0 RGB channel values",
+                  properties: {
+                    red: { type: "number", description: "Red channel (0.0 - 1.0)" },
+                    green: { type: "number", description: "Green channel (0.0 - 1.0)" },
+                    blue: { type: "number", description: "Blue channel (0.0 - 1.0)" },
+                    alpha: { type: "number", description: "Alpha channel (0.0 - 1.0)", default: 1 },
+                  },
+                },
+                backgroundColor: {
+                  type: "object",
+                  description: "Cell background color using 0.0-1.0 RGB channel values",
+                  properties: {
+                    red: { type: "number", description: "Red channel (0.0 - 1.0)" },
+                    green: { type: "number", description: "Green channel (0.0 - 1.0)" },
+                    blue: { type: "number", description: "Blue channel (0.0 - 1.0)" },
+                    alpha: { type: "number", description: "Alpha channel (0.0 - 1.0)", default: 1 },
+                  },
+                },
+                numberFormat: {
+                  type: "object",
+                  description: "Number formatting options",
+                  properties: {
+                    type: {
+                      type: "string",
+                      description: "Number format preset",
+                      enum: ["CURRENCY", "PERCENT", "DATE", "NUMBER", "TEXT"],
+                    },
+                    pattern: {
+                      type: "string",
+                      description: "Custom number format pattern (e.g., '$#,##0.00')",
+                    },
+                  },
+                  required: ["type"],
+                },
+              },
+            },
+          },
+          required: ["spreadsheetId", "range", "format"],
+        },
+      },
+      {
         name: "appendRows",
         description: "Append rows to a Google Sheets document",
         inputSchema: {
@@ -1726,6 +1808,101 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           content: [{
             type: "text",
             text: `Successfully updated ${values.length} rows in range ${range}`,
+          }],
+        };
+      }
+
+      case "formatCells": {
+        if (
+          !args ||
+          typeof args.spreadsheetId !== 'string' ||
+          typeof args.range !== 'string' ||
+          typeof args.format !== 'object' ||
+          args.format === null
+        ) {
+          throw new Error('spreadsheetId, range, and format parameters are required');
+        }
+
+        const { spreadsheetId, range } = args;
+        const formatOptions = args.format as FormatCellsInput;
+
+        const { sheetId, gridRange } = await resolveGridRange(sheets, spreadsheetId, range);
+
+        const cellFormat: CellFormat = {};
+        const textFormat: TextFormat = {};
+
+        if (typeof formatOptions.bold === 'boolean') {
+          textFormat.bold = formatOptions.bold;
+        }
+        if (typeof formatOptions.italic === 'boolean') {
+          textFormat.italic = formatOptions.italic;
+        }
+        if (typeof formatOptions.fontSize === 'number') {
+          textFormat.fontSize = {
+            magnitude: formatOptions.fontSize,
+            unit: 'PT',
+          };
+        }
+        if (formatOptions.foregroundColor && typeof formatOptions.foregroundColor === 'object') {
+          textFormat.foregroundColor = toSheetsColor(formatOptions.foregroundColor);
+        }
+
+        if (Object.keys(textFormat).length > 0) {
+          cellFormat.textFormat = textFormat;
+        }
+
+        if (formatOptions.backgroundColor && typeof formatOptions.backgroundColor === 'object') {
+          cellFormat.backgroundColor = toSheetsColor(formatOptions.backgroundColor);
+        }
+
+        if (
+          formatOptions.numberFormat &&
+          typeof formatOptions.numberFormat === 'object' &&
+          typeof formatOptions.numberFormat.type === 'string'
+        ) {
+          cellFormat.numberFormat = {
+            type: formatOptions.numberFormat.type,
+            pattern: typeof formatOptions.numberFormat.pattern === 'string'
+              ? formatOptions.numberFormat.pattern
+              : undefined,
+          };
+        }
+
+        if (!cellFormat.textFormat && !cellFormat.backgroundColor && !cellFormat.numberFormat) {
+          throw new Error('At least one formatting option must be provided');
+        }
+
+        const fieldMask = buildFieldMask(cellFormat);
+        if (!fieldMask) {
+          throw new Error('Unable to determine fields to update for formatCells');
+        }
+
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [
+              {
+                repeatCell: {
+                  range: gridRange,
+                  cell: { userEnteredFormat: cellFormat },
+                  fields: fieldMask,
+                },
+              },
+            ],
+          },
+        });
+
+        await cacheManager.invalidate(`sheet:${spreadsheetId}:*`);
+        clearSpreadsheetMetadata(spreadsheetId);
+        clearGridRangeCacheForSheet(sheetId);
+
+        performanceMonitor.track('formatCells', Date.now() - startTime);
+        logger.info('Cell formatting applied', { spreadsheetId, range, fields: fieldMask });
+
+        return {
+          content: [{
+            type: "text",
+            text: `Formatting applied to ${range}`,
           }],
         };
       }

--- a/src/__tests__/sheets/formatCells-helpers.test.ts
+++ b/src/__tests__/sheets/formatCells-helpers.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, afterEach } from '@jest/globals';
+import {
+  buildFieldMask,
+  parseA1Notation,
+  resetSheetHelperCaches,
+  toSheetsColor,
+  type CellFormat,
+} from '../../sheets/helpers.js';
+
+describe('Sheets formatting helpers', () => {
+  afterEach(() => {
+    resetSheetHelperCaches();
+  });
+
+  it('includes bold and italic fields when building field mask for text formatting', () => {
+    const cellFormat: CellFormat = {
+      textFormat: {
+        bold: true,
+        italic: true,
+      },
+    };
+
+    const mask = buildFieldMask(cellFormat);
+    const fields = mask.split(',').sort();
+
+    expect(fields).toEqual([
+      'userEnteredFormat.textFormat.bold',
+      'userEnteredFormat.textFormat.italic',
+    ]);
+  });
+
+  it('builds field mask for number format presets', () => {
+    const cellFormat: CellFormat = {
+      numberFormat: {
+        type: 'CURRENCY',
+        pattern: '$#,##0.00',
+      },
+    };
+
+    const mask = buildFieldMask(cellFormat);
+
+    expect(mask).toBe('userEnteredFormat.numberFormat');
+  });
+
+  it('captures combined formatting paths for text color, background color, and number format', () => {
+    const cellFormat: CellFormat = {
+      textFormat: {
+        bold: true,
+        foregroundColor: toSheetsColor({ red: 0.2, green: 0.4, blue: 0.6 }),
+      },
+      backgroundColor: toSheetsColor({ red: 0.95, green: 0.95, blue: 0.4 }),
+      numberFormat: {
+        type: 'PERCENT',
+        pattern: '0.00%',
+      },
+    };
+
+    const mask = buildFieldMask(cellFormat);
+    const fields = mask.split(',').sort();
+
+    expect(fields).toEqual([
+      'userEnteredFormat.backgroundColor',
+      'userEnteredFormat.numberFormat',
+      'userEnteredFormat.textFormat.bold',
+      'userEnteredFormat.textFormat.foregroundColor',
+    ]);
+  });
+
+  it('converts A1 notation ranges into grid ranges with zero-based indexes', () => {
+    const gridRange = parseA1Notation('B2:D5', 7);
+
+    expect(gridRange).toEqual({
+      sheetId: 7,
+      startRowIndex: 1,
+      endRowIndex: 5,
+      startColumnIndex: 1,
+      endColumnIndex: 4,
+    });
+  });
+});

--- a/src/sheets/helpers.ts
+++ b/src/sheets/helpers.ts
@@ -1,0 +1,325 @@
+import type { sheets_v4 } from 'googleapis';
+
+export type SheetsClient = sheets_v4.Sheets;
+export type GridRange = sheets_v4.Schema$GridRange;
+export type CellFormat = sheets_v4.Schema$CellFormat;
+export type TextFormat = sheets_v4.Schema$TextFormat;
+export type SheetsColor = sheets_v4.Schema$Color;
+
+export interface ColorInput {
+  red?: number;
+  green?: number;
+  blue?: number;
+  alpha?: number;
+}
+
+export interface FormatCellsNumberFormatInput {
+  type: string;
+  pattern?: string;
+}
+
+export interface FormatCellsInput {
+  bold?: boolean;
+  italic?: boolean;
+  fontSize?: number;
+  foregroundColor?: ColorInput;
+  backgroundColor?: ColorInput;
+  numberFormat?: FormatCellsNumberFormatInput;
+}
+
+interface SpreadsheetMetadata {
+  byTitle: Map<string, number>;
+  defaultSheetId?: number;
+}
+
+const spreadsheetMetadataCache = new Map<string, SpreadsheetMetadata>();
+const gridRangeCache = new Map<string, GridRange>();
+
+function normalizeRange(range: string): string {
+  return range.replace(/\$/g, '').replace(/\s+/g, '').toUpperCase();
+}
+
+function columnLetterToIndex(letters: string): number {
+  let index = 0;
+  for (const char of letters) {
+    index = index * 26 + (char.charCodeAt(0) - 64);
+  }
+  return index - 1;
+}
+
+function parseCellReference(ref: string): { rowIndex?: number; columnIndex?: number } {
+  if (!ref) {
+    return {};
+  }
+
+  const match = ref.match(/^([A-Z]*)(\d*)$/);
+  if (!match) {
+    throw new Error(`Invalid A1 notation segment: ${ref}`);
+  }
+
+  const [, letters, numbers] = match;
+  const result: { rowIndex?: number; columnIndex?: number } = {};
+
+  if (letters) {
+    result.columnIndex = columnLetterToIndex(letters);
+  }
+  if (numbers) {
+    result.rowIndex = parseInt(numbers, 10) - 1;
+  }
+
+  return result;
+}
+
+function extractSheetName(range: string): { sheetName?: string; rangeA1: string } {
+  const trimmed = range.trim();
+  if (!trimmed) {
+    return { rangeA1: '' };
+  }
+
+  const match = trimmed.match(/^(?:'((?:[^']|'')+)'|([^'!]+))!(.*)$/);
+  if (!match) {
+    return { rangeA1: trimmed };
+  }
+
+  const rawName = match[1] ?? match[2];
+  const parsedName = rawName ? rawName.replace(/''/g, "'") : undefined;
+  const rangeA1 = match[3] ?? '';
+
+  const result: { sheetName?: string; rangeA1: string } = { rangeA1 };
+  if (parsedName !== undefined) {
+    result.sheetName = parsedName;
+  }
+
+  return result;
+}
+
+async function fetchSpreadsheetMetadata(
+  sheetsClient: SheetsClient,
+  spreadsheetId: string,
+): Promise<SpreadsheetMetadata> {
+  const response = await sheetsClient.spreadsheets.get({ spreadsheetId });
+  const byTitle = new Map<string, number>();
+  let defaultSheetId: number | undefined;
+
+  for (const sheet of response.data.sheets ?? []) {
+    const id = sheet.properties?.sheetId;
+    if (id === undefined || id === null) {
+      continue;
+    }
+
+    const title = sheet.properties?.title;
+    if (title) {
+      byTitle.set(title, id);
+    }
+
+    if (defaultSheetId === undefined) {
+      defaultSheetId = id;
+    }
+  }
+
+  if (defaultSheetId === undefined) {
+    throw new Error(`No sheets found in spreadsheet ${spreadsheetId}`);
+  }
+
+  const metadata: SpreadsheetMetadata = {
+    byTitle,
+    defaultSheetId,
+  };
+
+  spreadsheetMetadataCache.set(spreadsheetId, metadata);
+  return metadata;
+}
+
+export async function getSheetId(
+  sheetsClient: SheetsClient,
+  spreadsheetId: string,
+  sheetName?: string,
+): Promise<number> {
+  let metadata = spreadsheetMetadataCache.get(spreadsheetId);
+  if (!metadata) {
+    metadata = await fetchSpreadsheetMetadata(sheetsClient, spreadsheetId);
+  }
+
+  if (sheetName) {
+    const sheetId = metadata.byTitle.get(sheetName);
+    if (sheetId === undefined) {
+      throw new Error(`Sheet "${sheetName}" not found in spreadsheet ${spreadsheetId}`);
+    }
+    return sheetId;
+  }
+
+  if (metadata.defaultSheetId === undefined) {
+    throw new Error(`No sheets found in spreadsheet ${spreadsheetId}`);
+  }
+
+  return metadata.defaultSheetId;
+}
+
+export function parseA1Notation(range: string, sheetId: number): GridRange {
+  if (!range.trim()) {
+    return { sheetId };
+  }
+
+  const normalized = normalizeRange(range);
+  const cacheKey = `${sheetId}:${normalized}`;
+  const cached = gridRangeCache.get(cacheKey);
+  if (cached) {
+    return { ...cached };
+  }
+
+  const parts = normalized.split(':');
+  const [startPart, endPart] = parts;
+  const startRef = parseCellReference(startPart ?? '');
+  const endRef = parseCellReference(parts.length > 1 ? endPart ?? '' : startPart ?? '');
+
+  const gridRange: GridRange = { sheetId };
+
+  if (startRef.rowIndex !== undefined) {
+    gridRange.startRowIndex = startRef.rowIndex;
+  }
+  if (startRef.columnIndex !== undefined) {
+    gridRange.startColumnIndex = startRef.columnIndex;
+  }
+
+  if (parts.length === 1) {
+    if (startRef.rowIndex !== undefined) {
+      gridRange.endRowIndex = startRef.rowIndex + 1;
+    }
+    if (startRef.columnIndex !== undefined) {
+      gridRange.endColumnIndex = startRef.columnIndex + 1;
+    }
+  } else {
+    if (endRef.rowIndex !== undefined) {
+      gridRange.endRowIndex = endRef.rowIndex + 1;
+    }
+    if (endRef.columnIndex !== undefined) {
+      gridRange.endColumnIndex = endRef.columnIndex + 1;
+    }
+  }
+
+  gridRangeCache.set(cacheKey, gridRange);
+  return { ...gridRange };
+}
+
+export async function resolveGridRange(
+  sheetsClient: SheetsClient,
+  spreadsheetId: string,
+  rangeInput: string,
+): Promise<{ sheetId: number; gridRange: GridRange; sheetName?: string }> {
+  const trimmed = rangeInput.trim();
+  const { sheetName: explicitSheetName, rangeA1 } = extractSheetName(trimmed);
+
+  let targetSheetId: number;
+  let sheetName = explicitSheetName;
+  let innerRange = rangeA1;
+
+  if (sheetName !== undefined) {
+    targetSheetId = await getSheetId(sheetsClient, spreadsheetId, sheetName);
+  } else {
+    targetSheetId = await getSheetId(sheetsClient, spreadsheetId);
+
+    if (innerRange) {
+      try {
+        targetSheetId = await getSheetId(sheetsClient, spreadsheetId, innerRange);
+        sheetName = innerRange;
+        innerRange = '';
+      } catch {
+        // Not a sheet name - treat as range on default sheet
+      }
+    }
+  }
+
+  const gridRange = innerRange
+    ? parseA1Notation(innerRange, targetSheetId)
+    : { sheetId: targetSheetId };
+
+  const result: { sheetId: number; gridRange: GridRange; sheetName?: string } = {
+    sheetId: targetSheetId,
+    gridRange,
+  };
+
+  if (sheetName !== undefined) {
+    result.sheetName = sheetName;
+  }
+
+  return result;
+}
+
+function collectFieldMask(value: unknown, prefix: string): string[] {
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    return prefix ? [prefix] : [];
+  }
+
+  const entries = Object.entries(value).filter(([, val]) => val !== undefined && val !== null);
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const hasNestedObject = entries.some(([, val]) => typeof val === 'object' && val !== null && !Array.isArray(val));
+
+  const shouldExpandChildren = hasNestedObject || (prefix.endsWith('textFormat') && entries.length > 0);
+
+  if (!shouldExpandChildren) {
+    return prefix ? [prefix] : [];
+  }
+
+  const result: string[] = [];
+  for (const [key, val] of entries) {
+    if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+      result.push(...collectFieldMask(val, prefix ? `${prefix}.${key}` : key));
+    } else if (prefix) {
+      result.push(`${prefix}.${key}`);
+    } else {
+      result.push(key);
+    }
+  }
+
+  return result;
+}
+
+export function buildFieldMask(format: CellFormat): string {
+  const fields = collectFieldMask({ userEnteredFormat: format }, '');
+  const uniqueFields = Array.from(new Set(fields.filter((field) => field.length > 0)));
+  return uniqueFields.join(',');
+}
+
+export function toSheetsColor(color: ColorInput): SheetsColor {
+  const sheetsColor: SheetsColor = {};
+
+  if (typeof color.red === 'number') {
+    sheetsColor.red = color.red;
+  }
+  if (typeof color.green === 'number') {
+    sheetsColor.green = color.green;
+  }
+  if (typeof color.blue === 'number') {
+    sheetsColor.blue = color.blue;
+  }
+  if (typeof color.alpha === 'number') {
+    sheetsColor.alpha = color.alpha;
+  }
+
+  return sheetsColor;
+}
+
+export function clearSpreadsheetMetadata(spreadsheetId: string): void {
+  spreadsheetMetadataCache.delete(spreadsheetId);
+}
+
+export function clearGridRangeCacheForSheet(sheetId: number): void {
+  const prefix = `${sheetId}:`;
+  for (const key of Array.from(gridRangeCache.keys())) {
+    if (key.startsWith(prefix)) {
+      gridRangeCache.delete(key);
+    }
+  }
+}
+
+export function resetSheetHelperCaches(): void {
+  spreadsheetMetadataCache.clear();
+  gridRangeCache.clear();
+}


### PR DESCRIPTION
## Summary
- add the `formatCells` tool schema and handler, leveraging shared range helpers and dynamic field masks
- introduce reusable Sheets helpers for resolving sheet IDs, parsing ranges, and building cell format masks
- document the new formatting workflow and cover bold/italic, number presets, and combined formatting in tests

## Testing
- npm test -- --runTestsByPath src/__tests__/sheets/formatCells-helpers.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68e97f345b708324bce18484f53db01b