### PR TITLE
feat: add advanced sheets tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- ✨ **Sheets advanced tools**: Added `mergeCells`, `setDataValidation`, and `createChart` MCP tools with robust error handling and cache invalidation.
+- 🧪 **Tests**: Added unit tests covering merge requests, dropdown validation payloads, and chart generation error handling.
+- 📝 **Docs**: Updated README, CLAUDE.md, and developer API guide with guidance for the new Sheets capabilities.
+
 ## [0.8.0] - 2025-08-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This is a Model Context Protocol (MCP) server for Google Drive integration. It p
 - Full read/write access to Google Drive files and folders
 - Resource access to Google Drive files via `gdrive:///<file_id>` URIs
 - Tools for searching, reading, creating, and updating files
-- Comprehensive Google Sheets operations (read, update, append)
+- Comprehensive Google Sheets operations (read, update, append, merge, validate, chart)
 - Google Forms creation and management with question types
 - **Google Docs API integration** - Create documents, insert text, replace text, apply formatting, insert tables
 - **Batch file operations** - Process multiple files in a single operation (create, update, delete, move)
@@ -85,7 +85,7 @@ Reference agents naturally in development tasks, e.g., "As dev, implement..." or
 - **Tools**: 
   - **Read Operations**: search, read, listSheets, readSheet
   - **Write Operations**: createFile, updateFile, createFolder
-  - **Sheets Operations**: updateCells, appendRows
+  - **Sheets Operations**: updateCells, appendRows, mergeCells, setDataValidation, createChart
   - **Forms Operations**: createForm, getForm, addQuestion, listResponses
   - **Docs Operations**: createDocument, insertText, replaceText, applyTextStyle, insertTable
   - **Batch Operations**: batchFileOperations (create, update, delete, move multiple files)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ node ./dist/index.js auth
 ### 📊 **Google Sheets Integration**
 - **Data Access** - Read and write sheet data with A1 notation support
 - **Sheet Management** - List sheets, update cells, append rows
+- **Advanced Controls** - Merge headers, enforce dropdown validation, and generate charts via tools
 - **CSV Export** - Automatic conversion for data analysis
 
 ### 📝 **Google Docs Manipulation**
@@ -206,11 +207,11 @@ graph TB
 
 ### 📖 Available Tools
 
-The server provides **22 comprehensive tools** for Google Workspace integration across **6 categories**:
+  The server provides **25 comprehensive tools** for Google Workspace integration across **6 categories**:
 
 - **🔍 Search & Read** (6 tools): search, enhancedSearch, read, listSheets, readSheet, getAppScript
 - **📁 File & Folder** (4 tools): createFile, updateFile, createFolder, batchFileOperations
-- **📊 Sheets** (2 tools): updateCells, appendRows
+- **📊 Sheets** (5 tools): updateCells, appendRows, mergeCells, setDataValidation, createChart
 - **📋 Forms** (4 tools): createForm, getForm, addQuestion, listResponses
 - **📝 Docs** (5 tools): createDocument, insertText, replaceText, applyTextStyle, insertTable
 - **📂 Resources**: MCP resource access via `gdrive:///<file_id>` URIs

--- a/docs/Developer-Guidelines/API.md
+++ b/docs/Developer-Guidelines/API.md
@@ -297,6 +297,9 @@ Common errors:
 - `createSheet`: Create new sheets in a spreadsheet
 - `formatSheet`: Apply formatting to cells
 - `setFormulas`: Add formulas to cells
+- `mergeCells`: Combine ranges for headers and grouped data
+- `setDataValidation`: Configure dropdown lists and numeric/date validation rules
+- `createChart`: Generate charts anchored to specific cells with overlay positioning
 
 #### createSheet tabColor format
 

--- a/src/__tests__/sheets/advancedFeatures.test.ts
+++ b/src/__tests__/sheets/advancedFeatures.test.ts
@@ -1,0 +1,292 @@
+import { jest } from '@jest/globals';
+import {
+  mergeCellsTool,
+  setDataValidationTool,
+  createChartTool,
+} from '../../sheets/advanced-tools.js';
+
+describe('Google Sheets advanced tools', () => {
+  let mockSheets: any;
+  let mockCache: any;
+  let mockPerformance: any;
+  let mockLogger: any;
+  let nowSpy: jest.SpiedFunction<typeof Date.now>;
+
+  const buildContext = () => ({
+    sheets: mockSheets,
+    cache: mockCache,
+    performance: mockPerformance,
+    logger: mockLogger,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    nowSpy = jest.spyOn(Date, 'now').mockReturnValue(2_000);
+
+    mockSheets = {
+      spreadsheets: {
+        get: jest.fn(() =>
+          Promise.resolve({
+            data: {
+              sheets: [
+                {
+                  properties: {
+                    sheetId: 42,
+                    title: 'Sheet1',
+                  },
+                },
+              ],
+            },
+          })
+        ),
+        batchUpdate: jest.fn(() => Promise.resolve({})),
+      },
+    };
+
+    mockCache = {
+      invalidate: jest.fn(() => Promise.resolve(undefined)),
+    };
+
+    mockPerformance = {
+      track: jest.fn(),
+    };
+
+    mockLogger = {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+  });
+
+  it('builds a mergeCells batch request with resolved sheet ID', async () => {
+    const args = {
+      spreadsheetId: 'spreadsheet-123',
+      range: 'Sheet1!A1:B2',
+      mergeType: 'MERGE_ROWS' as const,
+    };
+
+    const result = await mergeCellsTool(args, buildContext(), 1_000);
+
+    expect(mockSheets.spreadsheets.get).toHaveBeenCalledWith({
+      spreadsheetId: 'spreadsheet-123',
+      fields: 'sheets.properties(sheetId,title)',
+    });
+
+    expect(mockSheets.spreadsheets.batchUpdate).toHaveBeenCalledWith({
+      spreadsheetId: 'spreadsheet-123',
+      requestBody: {
+        requests: [
+          {
+            mergeCells: {
+              mergeType: 'MERGE_ROWS',
+              range: {
+                sheetId: 42,
+                startRowIndex: 0,
+                endRowIndex: 2,
+                startColumnIndex: 0,
+                endColumnIndex: 2,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(mockCache.invalidate).toHaveBeenCalledWith('sheet:spreadsheet-123:*');
+    expect(mockPerformance.track).toHaveBeenCalledWith('mergeCells', expect.any(Number));
+    expect(result.content?.[0]?.text).toContain('MERGE_ROWS');
+  });
+
+  it('logs and rethrows merge errors with context', async () => {
+    mockSheets.spreadsheets.batchUpdate.mockRejectedValueOnce(new Error('merge failed'));
+
+    await expect(
+      mergeCellsTool(
+        { spreadsheetId: 'sheet', range: 'Sheet1!A1:A2' },
+        buildContext(),
+        1_000
+      )
+    ).rejects.toThrow('Failed to merge cells in range Sheet1!A1:A2: merge failed');
+
+    const performanceCalls = mockPerformance.track.mock.calls as Array<
+      [string, number, boolean?]
+    >;
+    const errorCall = performanceCalls.find(
+      (call) => call[0] === 'mergeCells' && call[2] === true
+    );
+    expect(errorCall?.[2]).toBe(true);
+    expect(mockLogger.error).toHaveBeenCalledWith('mergeCells tool failed', expect.objectContaining({
+      spreadsheetId: 'sheet',
+    }));
+  });
+
+  it('applies dropdown validation with values converted to userEnteredValue', async () => {
+    const args = {
+      spreadsheetId: 'spreadsheet-123',
+      range: 'Sheet1!F2:F24',
+      validation: {
+        type: 'LIST_OF_VALUES' as const,
+        values: ['Layer 1', 'Layer 2'],
+        showDropdown: true,
+        strict: false,
+      },
+    };
+
+    await setDataValidationTool(args, buildContext(), 1_000);
+
+    const request = mockSheets.spreadsheets.batchUpdate.mock.calls[0][0];
+    expect(request).toEqual({
+      spreadsheetId: 'spreadsheet-123',
+      requestBody: {
+        requests: [
+          {
+            setDataValidation: {
+              range: {
+                sheetId: 42,
+                startRowIndex: 1,
+                endRowIndex: 24,
+                startColumnIndex: 5,
+                endColumnIndex: 6,
+              },
+              rule: {
+                condition: {
+                  type: 'LIST_OF_VALUES',
+                  values: [
+                    { userEnteredValue: 'Layer 1' },
+                    { userEnteredValue: 'Layer 2' },
+                  ],
+                },
+                strict: false,
+                showCustomUi: true,
+              },
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('throws validation errors before calling the API when values are missing', async () => {
+    await expect(
+      setDataValidationTool(
+        {
+          spreadsheetId: 'spreadsheet-123',
+          range: 'Sheet1!A1:A5',
+          validation: { type: 'LIST_OF_VALUES' },
+        },
+        buildContext(),
+        1_000
+      )
+    ).rejects.toThrow('validation.values must be a non-empty array for LIST_OF_VALUES');
+
+    expect(mockSheets.spreadsheets.batchUpdate).not.toHaveBeenCalled();
+  });
+
+  it('creates a basic chart with domain and series ranges split by column', async () => {
+    const args = {
+      spreadsheetId: 'spreadsheet-123',
+      sheetName: 'Sheet1',
+      chartType: 'LINE',
+      dataRange: 'Sheet1!A1:C10',
+      position: { row: 15, column: 1 },
+      title: 'Monthly Income',
+    };
+
+    await createChartTool(args, buildContext(), 1_000);
+
+    const request = mockSheets.spreadsheets.batchUpdate.mock.calls[0][0];
+    expect(request.requestBody.requests[0]).toEqual({
+      addChart: {
+        chart: {
+          spec: {
+            title: 'Monthly Income',
+            basicChart: {
+              chartType: 'LINE',
+              domains: [
+                {
+                  domain: {
+                    sourceRange: {
+                      sources: [
+                        {
+                          sheetId: 42,
+                          startRowIndex: 0,
+                          endRowIndex: 10,
+                          startColumnIndex: 0,
+                          endColumnIndex: 1,
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+              series: [
+                {
+                  series: {
+                    sourceRange: {
+                      sources: [
+                        {
+                          sheetId: 42,
+                          startRowIndex: 0,
+                          endRowIndex: 10,
+                          startColumnIndex: 1,
+                          endColumnIndex: 2,
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  series: {
+                    sourceRange: {
+                      sources: [
+                        {
+                          sheetId: 42,
+                          startRowIndex: 0,
+                          endRowIndex: 10,
+                          startColumnIndex: 2,
+                          endColumnIndex: 3,
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          position: {
+            overlayPosition: {
+              anchorCell: {
+                sheetId: 42,
+                rowIndex: 15,
+                columnIndex: 1,
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('rejects chart creation when the range lacks sufficient columns', async () => {
+    await expect(
+      createChartTool(
+        {
+          spreadsheetId: 'spreadsheet-123',
+          chartType: 'COLUMN',
+          dataRange: 'Sheet1!A1:A10',
+          position: { row: 0, column: 0 },
+        },
+        buildContext(),
+        1_000
+      )
+    ).rejects.toThrow('dataRange must include at least two columns for charting');
+
+    expect(mockSheets.spreadsheets.batchUpdate).not.toHaveBeenCalled();
+  });
+});
+

--- a/src/sheets/advanced-tools.ts
+++ b/src/sheets/advanced-tools.ts
@@ -1,0 +1,768 @@
+import type { sheets_v4 } from "googleapis";
+
+type SheetsClient = {
+  spreadsheets: {
+    get: (
+      params: sheets_v4.Params$Resource$Spreadsheets$Get
+    ) => Promise<{ data: sheets_v4.Schema$Spreadsheet }>;
+    batchUpdate: (
+      params: sheets_v4.Params$Resource$Spreadsheets$Batchupdate
+    ) => Promise<unknown>;
+  };
+};
+
+type CacheLike = {
+  invalidate: (pattern: string) => Promise<void>;
+};
+
+type PerformanceLike = {
+  track: (operation: string, duration: number, error?: boolean) => void;
+};
+
+type LoggerLike = {
+  info: (message: string, meta?: Record<string, unknown>) => void;
+  error: (message: string, meta?: Record<string, unknown>) => void;
+  warn?: (message: string, meta?: Record<string, unknown>) => void;
+  debug?: (message: string, meta?: Record<string, unknown>) => void;
+};
+
+interface ToolContext {
+  sheets: SheetsClient;
+  cache: CacheLike;
+  performance: PerformanceLike;
+  logger: LoggerLike;
+}
+
+type MergeType = "MERGE_ALL" | "MERGE_COLUMNS" | "MERGE_ROWS";
+
+interface MergeCellsArgs {
+  spreadsheetId: string;
+  range: string;
+  mergeType?: MergeType;
+}
+
+interface DataValidationArgs {
+  spreadsheetId: string;
+  range: string;
+  validation: {
+    type: "LIST_OF_VALUES" | "NUMBER_BETWEEN" | "DATE_AFTER";
+    values?: string[];
+    min?: number | string;
+    max?: number | string;
+    strict?: boolean;
+    showDropdown?: boolean;
+  };
+}
+
+interface CreateChartArgs {
+  spreadsheetId: string;
+  sheetName?: string;
+  chartType: string;
+  dataRange: string;
+  position: { row: number; column: number };
+  title?: string;
+}
+
+interface ToolResponse {
+  content: Array<{ type: "text"; text: string }>;
+}
+
+type GridRange = sheets_v4.Schema$GridRange;
+type ChartSourceRange = sheets_v4.Schema$ChartSourceRange;
+
+const MERGE_TYPES: ReadonlySet<MergeType> = new Set([
+  "MERGE_ALL",
+  "MERGE_COLUMNS",
+  "MERGE_ROWS",
+]);
+
+const CHART_TYPES: ReadonlySet<string> = new Set([
+  "LINE",
+  "BAR",
+  "COLUMN",
+  "PIE",
+  "SCATTER",
+]);
+
+export async function mergeCellsTool(
+  rawArgs: unknown,
+  context: ToolContext,
+  startTime: number
+): Promise<ToolResponse> {
+  const args = validateMergeCellsArgs(rawArgs);
+
+  try {
+    const { sheetId, title } = await resolveSheetId(
+      context.sheets,
+      args.spreadsheetId,
+      context.logger,
+      undefined,
+      args.range
+    );
+
+    const gridRange = parseA1Notation(args.range, sheetId);
+
+    await context.sheets.spreadsheets.batchUpdate({
+      spreadsheetId: args.spreadsheetId,
+      requestBody: {
+        requests: [
+          {
+            mergeCells: {
+              range: gridRange,
+              mergeType: args.mergeType ?? "MERGE_ALL",
+            },
+          },
+        ],
+      },
+    });
+
+    await context.cache.invalidate(`sheet:${args.spreadsheetId}:*`);
+
+    context.performance.track("mergeCells", Date.now() - startTime);
+    context.logger.info("Cells merged", {
+      spreadsheetId: args.spreadsheetId,
+      sheetId,
+      sheetTitle: title,
+      range: gridRange,
+      mergeType: args.mergeType ?? "MERGE_ALL",
+    });
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Merged range ${args.range} using ${args.mergeType ?? "MERGE_ALL"}`,
+        },
+      ],
+    };
+  } catch (error) {
+    context.performance.track("mergeCells", Date.now() - startTime, true);
+    context.logger.error("mergeCells tool failed", {
+      error,
+      spreadsheetId: args.spreadsheetId,
+      range: args.range,
+    });
+
+    throw wrapError(error, (message) =>
+      message.startsWith("Failed to")
+        ? message
+        : `Failed to merge cells in range ${args.range}: ${message}`
+    );
+  }
+}
+
+export async function setDataValidationTool(
+  rawArgs: unknown,
+  context: ToolContext,
+  startTime: number
+): Promise<ToolResponse> {
+  const args = validateDataValidationArgs(rawArgs);
+
+  try {
+    const { sheetId, title } = await resolveSheetId(
+      context.sheets,
+      args.spreadsheetId,
+      context.logger,
+      undefined,
+      args.range
+    );
+
+    const gridRange = parseA1Notation(args.range, sheetId);
+    const rule = buildDataValidationRule(args.validation);
+
+    await context.sheets.spreadsheets.batchUpdate({
+      spreadsheetId: args.spreadsheetId,
+      requestBody: {
+        requests: [
+          {
+            setDataValidation: {
+              range: gridRange,
+              rule,
+            },
+          },
+        ],
+      },
+    });
+
+    await context.cache.invalidate(`sheet:${args.spreadsheetId}:*`);
+
+    context.performance.track("setDataValidation", Date.now() - startTime);
+    context.logger.info("Data validation applied", {
+      spreadsheetId: args.spreadsheetId,
+      sheetId,
+      sheetTitle: title,
+      range: gridRange,
+      type: args.validation.type,
+    });
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Applied ${args.validation.type} validation to ${args.range}`,
+        },
+      ],
+    };
+  } catch (error) {
+    context.performance.track("setDataValidation", Date.now() - startTime, true);
+    context.logger.error("setDataValidation tool failed", {
+      error,
+      spreadsheetId: args.spreadsheetId,
+      range: args.range,
+    });
+
+    throw wrapError(error, (message) =>
+      message.startsWith("Failed to")
+        ? message
+        : `Failed to set data validation on ${args.range}: ${message}`
+    );
+  }
+}
+
+export async function createChartTool(
+  rawArgs: unknown,
+  context: ToolContext,
+  startTime: number
+): Promise<ToolResponse> {
+  const args = validateCreateChartArgs(rawArgs);
+
+  try {
+    const { sheetId, title } = await resolveSheetId(
+      context.sheets,
+      args.spreadsheetId,
+      context.logger,
+      args.sheetName,
+      args.dataRange
+    );
+
+    const gridRange = parseA1Notation(args.dataRange, sheetId);
+    const chartRequest = buildChartRequest(gridRange, args);
+
+    await context.sheets.spreadsheets.batchUpdate({
+      spreadsheetId: args.spreadsheetId,
+      requestBody: {
+        requests: [chartRequest],
+      },
+    });
+
+    await context.cache.invalidate(`sheet:${args.spreadsheetId}:*`);
+
+    context.performance.track("createChart", Date.now() - startTime);
+    context.logger.info("Chart created", {
+      spreadsheetId: args.spreadsheetId,
+      sheetId,
+      sheetTitle: title,
+      dataRange: gridRange,
+      chartType: args.chartType,
+      anchor: args.position,
+    });
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `${args.chartType} chart created at row ${args.position.row}, column ${args.position.column}`,
+        },
+      ],
+    };
+  } catch (error) {
+    context.performance.track("createChart", Date.now() - startTime, true);
+    context.logger.error("createChart tool failed", {
+      error,
+      spreadsheetId: args.spreadsheetId,
+      dataRange: args.dataRange,
+    });
+
+    throw wrapError(error, (message) =>
+      message.startsWith("Failed to")
+        ? message
+        : `Failed to create chart from ${args.dataRange}: ${message}`
+    );
+  }
+}
+
+function validateMergeCellsArgs(rawArgs: unknown): MergeCellsArgs {
+  if (!rawArgs || typeof rawArgs !== "object") {
+    throw new Error("Arguments are required for mergeCells");
+  }
+
+  const { spreadsheetId, range, mergeType } = rawArgs as Partial<MergeCellsArgs>;
+
+  if (typeof spreadsheetId !== "string" || spreadsheetId.trim() === "") {
+    throw new Error("spreadsheetId must be a non-empty string");
+  }
+
+  if (typeof range !== "string" || range.trim() === "") {
+    throw new Error("range must be provided in A1 notation");
+  }
+
+  if (mergeType && !MERGE_TYPES.has(mergeType)) {
+    throw new Error(
+      "mergeType must be one of MERGE_ALL, MERGE_COLUMNS, or MERGE_ROWS"
+    );
+  }
+
+  const normalized: MergeCellsArgs = {
+    spreadsheetId,
+    range,
+  };
+
+  if (mergeType !== undefined) {
+    normalized.mergeType = mergeType;
+  }
+
+  return normalized;
+}
+
+function validateDataValidationArgs(rawArgs: unknown): DataValidationArgs {
+  if (!rawArgs || typeof rawArgs !== "object") {
+    throw new Error("Arguments are required for setDataValidation");
+  }
+
+  const { spreadsheetId, range, validation } = rawArgs as Partial<DataValidationArgs>;
+
+  if (typeof spreadsheetId !== "string" || spreadsheetId.trim() === "") {
+    throw new Error("spreadsheetId must be a non-empty string");
+  }
+
+  if (typeof range !== "string" || range.trim() === "") {
+    throw new Error("range must be provided in A1 notation");
+  }
+
+  if (!validation || typeof validation !== "object") {
+    throw new Error("validation configuration is required");
+  }
+
+  const { type } = validation;
+  if (type !== "LIST_OF_VALUES" && type !== "NUMBER_BETWEEN" && type !== "DATE_AFTER") {
+    throw new Error(
+      "validation.type must be LIST_OF_VALUES, NUMBER_BETWEEN, or DATE_AFTER"
+    );
+  }
+
+  const normalizedValidation = validation as DataValidationArgs["validation"];
+
+  return {
+    spreadsheetId,
+    range,
+    validation: normalizedValidation,
+  };
+}
+
+function validateCreateChartArgs(rawArgs: unknown): CreateChartArgs {
+  if (!rawArgs || typeof rawArgs !== "object") {
+    throw new Error("Arguments are required for createChart");
+  }
+
+  const { spreadsheetId, sheetName, chartType, dataRange, position, title } =
+    rawArgs as Partial<CreateChartArgs>;
+
+  if (typeof spreadsheetId !== "string" || spreadsheetId.trim() === "") {
+    throw new Error("spreadsheetId must be a non-empty string");
+  }
+
+  if (typeof chartType !== "string" || chartType.trim() === "") {
+    throw new Error("chartType must be provided");
+  }
+
+  const normalizedChartType = chartType.toUpperCase();
+  if (!CHART_TYPES.has(normalizedChartType)) {
+    throw new Error(
+      "chartType must be one of LINE, BAR, COLUMN, PIE, or SCATTER"
+    );
+  }
+
+  if (typeof dataRange !== "string" || dataRange.trim() === "") {
+    throw new Error("dataRange must be provided in A1 notation");
+  }
+
+  if (!position || typeof position !== "object") {
+    throw new Error("position with row and column is required");
+  }
+
+  if (!Number.isInteger(position.row) || position.row < 0) {
+    throw new Error("position.row must be a non-negative integer");
+  }
+
+  if (!Number.isInteger(position.column) || position.column < 0) {
+    throw new Error("position.column must be a non-negative integer");
+  }
+
+  const normalized: CreateChartArgs = {
+    spreadsheetId,
+    chartType: normalizedChartType,
+    dataRange,
+    position,
+  };
+
+  if (sheetName !== undefined) {
+    normalized.sheetName = sheetName;
+  }
+
+  if (title !== undefined) {
+    normalized.title = title;
+  }
+
+  return normalized;
+}
+
+function buildDataValidationRule(
+  validation: DataValidationArgs["validation"]
+): sheets_v4.Schema$DataValidationRule {
+  let values: Array<{ userEnteredValue: string }> | undefined;
+
+  switch (validation.type) {
+    case "LIST_OF_VALUES": {
+      if (!validation.values || validation.values.length === 0) {
+        throw new Error(
+          "validation.values must be a non-empty array for LIST_OF_VALUES"
+        );
+      }
+      values = validation.values.map((value) => ({
+        userEnteredValue: value,
+      }));
+      break;
+    }
+    case "NUMBER_BETWEEN": {
+      if (validation.min === undefined || validation.max === undefined) {
+        throw new Error(
+          "validation.min and validation.max are required for NUMBER_BETWEEN"
+        );
+      }
+      values = [
+        { userEnteredValue: String(validation.min) },
+        { userEnteredValue: String(validation.max) },
+      ];
+      break;
+    }
+    case "DATE_AFTER": {
+      if (validation.min === undefined) {
+        throw new Error(
+          "validation.min is required for DATE_AFTER validations"
+        );
+      }
+      values = [{ userEnteredValue: String(validation.min) }];
+      break;
+    }
+  }
+
+  return {
+    condition: {
+      type: validation.type,
+      values,
+    },
+    strict: validation.strict ?? true,
+    showCustomUi: validation.showDropdown ?? true,
+  };
+}
+
+function buildChartRequest(
+  gridRange: GridRange,
+  args: CreateChartArgs
+): sheets_v4.Schema$Request {
+  const startColumn = gridRange.startColumnIndex ?? null;
+  const endColumn = gridRange.endColumnIndex ?? null;
+
+  if (startColumn === null) {
+    throw new Error("dataRange must specify a starting column");
+  }
+
+  if (endColumn === null) {
+    throw new Error("dataRange must specify an ending column");
+  }
+
+  if (endColumn - startColumn < 2) {
+    throw new Error("dataRange must include at least two columns for charting");
+  }
+
+  const domainRange = cloneRange(gridRange, {
+    startColumnIndex: startColumn,
+    endColumnIndex: startColumn + 1,
+  });
+
+  const seriesRanges: GridRange[] = [];
+  for (let column = startColumn + 1; column < endColumn; column++) {
+    seriesRanges.push(
+      cloneRange(gridRange, {
+        startColumnIndex: column,
+        endColumnIndex: column + 1,
+      })
+    );
+  }
+
+  const domainSource: ChartSourceRange = {
+    sources: [domainRange],
+  };
+
+  const seriesSources: ChartSourceRange[] = seriesRanges.map((range) => ({
+    sources: [range],
+  }));
+
+  const sheetIdValue = gridRange.sheetId;
+  if (sheetIdValue === undefined || sheetIdValue === null) {
+    throw new Error("A sheetId is required to position the chart");
+  }
+
+  const chartTypeValue = args.chartType as Exclude<
+    sheets_v4.Schema$BasicChartSpec["chartType"],
+    undefined
+  >;
+
+  return {
+    addChart: {
+      chart: {
+        spec: {
+          title: args.title ?? null,
+          basicChart: {
+            chartType: chartTypeValue,
+            domains: [
+              {
+                domain: {
+                  sourceRange: domainSource,
+                },
+              },
+            ],
+            series: seriesSources.map((sourceRange) => ({
+              series: {
+                sourceRange,
+              },
+            })),
+          },
+        },
+        position: {
+          overlayPosition: {
+            anchorCell: {
+              sheetId: sheetIdValue,
+              rowIndex: args.position.row,
+              columnIndex: args.position.column,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function resolveSheetId(
+  sheets: SheetsClient,
+  spreadsheetId: string,
+  logger: LoggerLike,
+  sheetName?: string,
+  range?: string
+): Promise<{ sheetId: number; title: string }> {
+  const desiredSheetName = (sheetName ?? extractSheetName(range))?.trim();
+
+  return sheets.spreadsheets
+    .get({
+      spreadsheetId,
+      fields: "sheets.properties(sheetId,title)",
+    })
+    .then((response) => {
+      const sheetsData = response.data.sheets ?? [];
+
+      let match = sheetsData[0];
+      if (desiredSheetName) {
+        match = sheetsData.find(
+          (sheet) => sheet.properties?.title === desiredSheetName
+        );
+      }
+
+      const matchedSheetId = match?.properties?.sheetId;
+
+      if (!match || matchedSheetId === undefined || matchedSheetId === null) {
+        throw new Error(
+          desiredSheetName
+            ? `Sheet "${desiredSheetName}" not found`
+            : "No sheets available in spreadsheet"
+        );
+      }
+
+      const resolvedTitle = match?.properties?.title ?? desiredSheetName ?? "";
+
+      return {
+        sheetId: matchedSheetId,
+        title: resolvedTitle,
+      };
+    })
+    .catch((error) => {
+      logger.error("Failed to resolve sheet ID", {
+        error,
+        spreadsheetId,
+        sheetName: desiredSheetName,
+      });
+      throw wrapError(error, (message) =>
+        `Failed to resolve sheet in spreadsheet ${spreadsheetId}${
+          desiredSheetName ? ` for sheet "${desiredSheetName}"` : ""
+        }: ${message}`
+      );
+    });
+}
+
+function extractSheetName(range?: string): string | undefined {
+  if (!range) {
+    return undefined;
+  }
+
+  const delimiterIndex = range.indexOf("!");
+  if (delimiterIndex === -1) {
+    return undefined;
+  }
+
+  const sheetPart = range.slice(0, delimiterIndex).trim();
+  return unescapeSheetName(sheetPart);
+}
+
+function parseA1Notation(range: string, sheetId: number): GridRange {
+  const trimmed = stripSheetPrefix(range).trim();
+
+  if (!trimmed) {
+    return { sheetId };
+  }
+
+  if (trimmed.includes(",")) {
+    throw new Error(`Invalid A1 range: ${range}`);
+  }
+
+  const parts = trimmed.split(":");
+  if (parts.length > 2) {
+    throw new Error(`Invalid A1 range: ${range}`);
+  }
+
+  const startToken = parts[0] ?? "";
+  const startRef = parseSingleReference(startToken);
+  const endToken = parts[1];
+  const hasEnd = parts.length === 2 && (endToken?.trim() ?? "") !== "";
+  const endRef = hasEnd ? parseSingleReference(endToken ?? "") : undefined;
+
+  const gridRange: GridRange = { sheetId };
+
+  if (startRef.row !== undefined) {
+    gridRange.startRowIndex = startRef.row;
+    if (hasEnd && endRef?.row !== undefined) {
+      gridRange.endRowIndex = endRef.row + 1;
+    } else if (!hasEnd) {
+      gridRange.endRowIndex = startRef.row + 1;
+    }
+  } else if (hasEnd && endRef?.row !== undefined) {
+    gridRange.startRowIndex = 0;
+    gridRange.endRowIndex = endRef.row + 1;
+  }
+
+  if (startRef.column !== undefined) {
+    gridRange.startColumnIndex = startRef.column;
+    if (hasEnd && endRef?.column !== undefined) {
+      gridRange.endColumnIndex = endRef.column + 1;
+    } else if (!hasEnd) {
+      gridRange.endColumnIndex = startRef.column + 1;
+    }
+  } else if (hasEnd && endRef?.column !== undefined) {
+    gridRange.startColumnIndex = 0;
+    gridRange.endColumnIndex = endRef.column + 1;
+  }
+
+  return gridRange;
+}
+
+function parseSingleReference(reference: string): {
+  row?: number;
+  column?: number;
+} {
+  const normalized = reference.trim().toUpperCase();
+  if (normalized === "") {
+    return {};
+  }
+
+  const match = normalized.match(/^([A-Z]+)?(\d+)?$/);
+  if (!match) {
+    throw new Error(`Invalid A1 reference: ${reference}`);
+  }
+
+  const [, columnPart, rowPart] = match;
+  const result: { row?: number; column?: number } = {};
+
+  if (columnPart) {
+    result.column = columnLabelToIndex(columnPart);
+  }
+
+  if (rowPart) {
+    result.row = parseInt(rowPart, 10) - 1;
+  }
+
+  return result;
+}
+
+function columnLabelToIndex(label: string): number {
+  let index = 0;
+  for (const char of label) {
+    const code = char.charCodeAt(0);
+    if (code < 65 || code > 90) {
+      throw new Error(`Invalid column label: ${label}`);
+    }
+    index = index * 26 + (code - 64);
+  }
+  return index - 1;
+}
+
+function stripSheetPrefix(range: string): string {
+  const delimiterIndex = range.indexOf("!");
+  return delimiterIndex === -1 ? range : range.slice(delimiterIndex + 1);
+}
+
+function unescapeSheetName(name: string): string {
+  if (name.startsWith("'") && name.endsWith("'")) {
+    const inner = name.slice(1, -1);
+    return inner.replace(/''/g, "'");
+  }
+  return name;
+}
+
+function cloneRange(range: GridRange, overrides: Partial<GridRange>): GridRange {
+  const cloned: GridRange = {};
+
+  if (range.sheetId !== undefined) {
+    cloned.sheetId = range.sheetId;
+  }
+  if (range.startRowIndex !== undefined) {
+    cloned.startRowIndex = range.startRowIndex;
+  }
+  if (range.endRowIndex !== undefined) {
+    cloned.endRowIndex = range.endRowIndex;
+  }
+  if (range.startColumnIndex !== undefined) {
+    cloned.startColumnIndex = range.startColumnIndex;
+  }
+  if (range.endColumnIndex !== undefined) {
+    cloned.endColumnIndex = range.endColumnIndex;
+  }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value !== undefined) {
+      (cloned as Record<string, unknown>)[key] = value;
+    }
+  }
+
+  return cloned;
+}
+
+function wrapError(
+  error: unknown,
+  messageBuilder: (message: string) => string
+): Error {
+  const message = messageBuilder(toErrorMessage(error));
+  return new Error(message);
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+


### PR DESCRIPTION
## Summary
- register mergeCells, setDataValidation, and createChart tools with schemas in the MCP server
- implement shared helpers to resolve sheet IDs, parse A1 ranges, and build merge, validation, and chart batch requests with logging and cache invalidation
- expand documentation for the new capabilities and add focused unit tests covering happy paths and error handling

## Testing
- npm test -- --runTestsByPath src/__tests__/sheets/advancedFeatures.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68e97f37f2088324bb13ef84a57b2aa7