### PR TITLE
feat(gmail): add getTrackingData operation for campaign open tracking

### DIFF
--- a/src/tools/listTools.ts
+++ b/src/tools/listTools.ts
@@ -291,6 +291,12 @@ export async function generateToolStructure(): Promise<ModuleStructure> {
         description: 'Permanently delete a draft by ID. This operation cannot be undone.',
         example: 'const result = await gmail.deleteDraft({ draftId: "r1234567890" });\nconsole.log(result.message); // "Draft r1234567890 deleted"',
       },
+      {
+        name: 'getTrackingData',
+        signature: 'getTrackingData({ campaignId: string })',
+        description: 'Query email open-tracking data for a campaign. Returns totalOpens, uniqueOpens, and per-recipient open counts with timestamps. Worker-only — requires CF Workers runtime with KV namespace. Campaign IDs come from tracking pixels embedded in outreach emails.',
+        example: 'const data = await gmail.getTrackingData({ campaignId: "q1-outreach-2026" });\nconsole.log(`Opens: ${data.totalOpens} total, ${data.uniqueOpens} unique`);\ndata.recipients.forEach(r => console.log(r.recipientId, r.openCount));',
+      },
     ],
     calendar: [
       {


### PR DESCRIPTION
## Summary

Wires `gmail.getTrackingData` into `listTools.ts`, completing the full SDK surface for the campaign open-tracking feature.

## Changes

- **`src/tools/listTools.ts`** — added `getTrackingData` entry to the gmail tool list (was missing from tool registry)

## What was already implemented (GDRIVE-19)

All of the following were already in place on `main`:
- `getTrackingData()` function in `src/server/tracking.ts`
- SDK spec entry in `src/sdk/spec.ts`  
- Runtime registration in `src/sdk/runtime.ts`
- Type declaration in `src/sdk/types.ts`
- Tests in `src/server/__tests__/tracking.test.ts` (6 tests, all passing)

## Acceptance Criteria

- [x] AC-1: Returns aggregated tracking data (totalOpens, uniqueOpens) for a given campaignId
- [x] AC-2: Per-recipient detail includes open status, firstOpenedAt, lastOpenedAt, openCount
- [x] AC-3: Gracefully handles campaigns with no tracking data (returns zeroed aggregates)

## Tests

```
Test Suites: 51 passed, 51 total
Tests:       4 skipped, 581 passed, 585 total
```

Closes #53
Resolves GDRIVE-20